### PR TITLE
Remove styling from login page

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,8 +13,6 @@ st.set_page_config(page_title="DGSN - Reconnaissance Faciale", page_icon="logo.p
 initialize_deepface()
 if cursor:
     setup_db()
-load_css()
-app_header()
 
 # Gestion de l'état "busy"
 if "busy" not in st.session_state:
@@ -48,4 +46,6 @@ if "authenticated" not in st.session_state:
 if not st.session_state["authenticated"]:
     login_page()
 else:
+    load_css()
+    app_header()
     main_page()

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -12,9 +12,8 @@ __all__ = ["load_css", "show_running_ui", "app_header", "login_page", "main_page
 
 
 def login_page() -> None:
-    st.markdown('<div class="app-center login-page"><div class="login-card">', unsafe_allow_html=True)
     st.image("logo.png", width=80)
-    st.markdown('<h2 class="login-title">Connexion</h2>', unsafe_allow_html=True)
+    st.header("Connexion")
     with st.form("login_form", clear_on_submit=False):
         username = st.text_input("Nom d'utilisateur")
         password = st.text_input("Mot de passe", type="password")
@@ -30,7 +29,6 @@ def login_page() -> None:
             st.rerun()
         else:
             st.error("❌ Nom d'utilisateur ou mot de passe incorrect.")
-    st.markdown("</div></div>", unsafe_allow_html=True)
 
 
 def navigate(page_key: str) -> None:

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -37,28 +37,6 @@ html, body, [data-testid="stAppViewContainer"] {
   max-width: 1200px;
 }
 
-.app-center {
-  min-height: calc(100vh - 80px);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.login-card {
-  background: var(--brand-surface);
-  padding: 2.5rem 2rem;
-  border-radius: 16px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.4);
-  width: 100%;
-  max-width: 480px;
-}
-
-.login-title {
-  color: var(--brand-accent);
-  text-align: center;
-  margin-bottom: 1.5rem;
-}
-
 [data-testid="stSidebar"] {
   background: var(--brand-bg);
 }


### PR DESCRIPTION
## Summary
- Remove custom CSS and HTML wrappers from login page
- Load global styling only after authentication to keep login unstyled
- Drop unused login CSS definitions

## Testing
- `python -m py_compile main.py ui/__init__.py ui/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5b1d6a294832b9946d9ccf1418117