### PR TITLE
Remove custom login page styling

### DIFF
--- a/login_app.py
+++ b/login_app.py
@@ -7,120 +7,6 @@ from utils import initialize_deepface
 from ui import main_page, load_css, app_header
 
 
-def apply_brand_css() -> None:
-    """Injecte le bloc CSS de marque."""
-    st.markdown(
-        """
-        <style>
-        :root {
-            --brand-bg: #0d1b2a; /* à ajuster selon charte DGSN */
-            --brand-surface: #1b263b; /* à ajuster selon charte DGSN */
-            --brand-accent: #d32f2f; /* à ajuster selon charte DGSN */
-            --brand-border: rgba(255,255,255,0.1); /* à ajuster selon charte DGSN */
-            --brand-text: #ffffff; /* à ajuster selon charte DGSN */
-            --brand-muted: #8b949e; /* à ajuster selon charte DGSN */
-        }
-
-        html, body, [data-testid="stAppViewContainer"] {
-            background: var(--brand-bg);
-            color: var(--brand-text);
-        }
-        [data-testid="block-container"] {
-            max-width: 1000px;
-            padding-top: 0;
-            padding-bottom: 0;
-        }
-        .app-center {
-            min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            padding: 1rem;
-        }
-        .login-card {
-            background: var(--brand-surface);
-            border: 1px solid var(--brand-border);
-            border-radius: 12px;
-            box-shadow: 0 4px 12px rgba(0,0,0,0.2);
-            width: 100%;
-            max-width: 480px;
-            padding: 2.5rem 2rem;
-        }
-        .login-card img {
-            display: block;
-            margin: 0 auto 1.5rem auto;
-            height: auto;
-        }
-        .page-title {
-            position: relative;
-            text-align: center;
-            margin-bottom: 2rem;
-            color: var(--brand-text);
-        }
-        .page-title::after {
-            content: "";
-            position: absolute;
-            bottom: -0.5rem;
-            left: 50%;
-            transform: translateX(-50%);
-            width: 40px;
-            height: 4px;
-            background: var(--brand-accent);
-            border-radius: 2px;
-        }
-        .muted { color: var(--brand-muted); }
-        .accent { color: var(--brand-accent); }
-        .danger { color: var(--brand-accent); }
-        .link-button button {
-            background: none;
-            border: none;
-            color: var(--brand-accent);
-            text-decoration: underline;
-            padding: 0;
-        }
-        .link-button button:hover {
-            color: var(--brand-text);
-            background: none;
-        }
-        .stTextInput>div>div>input {
-            color: var(--brand-text);
-        }
-        .stTextInput>div>div>input:focus {
-            border-color: var(--brand-accent);
-            box-shadow: 0 0 0 1px var(--brand-accent);
-        }
-        .stCheckbox>label {
-            color: var(--brand-text);
-        }
-        .stButton>button {
-            background: var(--brand-accent);
-            color: var(--brand-bg);
-            border-radius: 8px;
-            border: 1px solid var(--brand-border);
-        }
-        .stButton>button:hover:enabled {
-            filter: brightness(1.1);
-        }
-        .stButton>button:focus {
-            outline: 2px solid var(--brand-accent);
-            outline-offset: 2px;
-        }
-        .stButton>button:disabled {
-            opacity: 0.5;
-            cursor: not-allowed;
-        }
-        @media (max-width: 600px) {
-            .login-card {
-                padding: 2rem 1rem;
-                max-width: 90%;
-            }
-        }
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
-
-
 def validate_credentials(username: str, password: str) -> bool:
     """Vérifie les identifiants via la base de données."""
     user = authenticate_user(cursor, username, password)
@@ -142,9 +28,8 @@ def _lockout_remaining() -> int:
 
 def build_login_page() -> None:
     _init_session_state()
-    st.markdown("<div class='app-center'><div class='login-card'>", unsafe_allow_html=True)
     st.image("logo.png", width=96)
-    st.markdown("<h1 class='page-title'>Connexion</h1>", unsafe_allow_html=True)
+    st.title("Connexion")
 
     locked = time() < st.session_state["lockout_until"]
     username_default = st.session_state.get("remembered_username", "")
@@ -173,9 +58,7 @@ def build_login_page() -> None:
             disabled=locked or not username or not password,
         )
 
-    st.markdown("<div class='link-button' style='text-align:right'>", unsafe_allow_html=True)
     forgot_clicked = st.button("Mot de passe oublié ?")
-    st.markdown("</div>", unsafe_allow_html=True)
 
     if forgot_clicked:
         st.info("Veuillez contacter l'administrateur pour réinitialiser votre mot de passe.")
@@ -214,7 +97,6 @@ def build_login_page() -> None:
                 st.session_state["lockout_until"] = time() + 60
                 st.warning("Trop de tentatives. Bouton désactivé 60s.")
 
-    st.markdown("</div></div>", unsafe_allow_html=True)
 
 st.set_page_config(
     page_title="DGSN - Reconnaissance Faciale",
@@ -234,5 +116,4 @@ if st.session_state["authenticated"]:
     app_header()
     main_page()
 else:
-    apply_brand_css()
     build_login_page()

--- a/style.css
+++ b/style.css
@@ -274,69 +274,6 @@ img:hover {
   background: #1b263b !important;
 }
 
-/* NOUVEAU: Style de la page de connexion bleu */
-.login-page [data-testid="stForm"] {
-  width: 450px;
-  margin: 8vh auto 0 auto;
-  padding: 28px;
-  border-radius: 12px;
-  background: #1b263b;
-  border: 1px solid #415a77;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
-  color: #e0e0e0;
-}
-
-.login-page h1, .login-page h2, .login-page h3, .login-page p {
-  color: #e0e0e0 !important;
-}
-
-.login-page label p {
-  color: #bdbdbd !important;
-  font-weight: 600;
-  margin-bottom: 8px;
-}
-
-.login-page input[type="text"], .login-page input[type="password"] {
-  background: #0d1b2a !important;
-  color: #e0e0e0 !important;
-  border-radius: 8px !important;
-  border: 1px solid #415a77 !important;
-  padding: 12px 16px !important;
-  font-size: 16px !important;
-  font-weight: 500 !important;
-}
-
-.login-page input[type="text"]:focus, .login-page input[type="password"]:focus {
-  border-color: #d32f2f !important;
-  box-shadow: 0 0 0 2px rgba(211, 47, 47, 0.2) !important;
-  background: #1b263b !important;
-}
-
-.login-page button[kind="primary"] {
-  background: linear-gradient(135deg, #d32f2f 0%, #b71c1c 100%) !important;
-  border-radius: 8px !important;
-  font-weight: 700 !important;
-  padding: 12px 24px !important;
-  font-size: 16px !important;
-  margin-top: 16px !important;
-  width: 100% !important;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-}
-
-.login-page button[kind="primary"]:hover {
-  background: linear-gradient(135deg, #b71c1c 0%, #9a0007 100%) !important;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.4);
-}
-
-.login-title {
-  text-align: center;
-  margin: 24px 0 20px 0;
-  color: #d32f2f;
-  font-weight: 800;
-  font-size: 28px;
-}
-
 /* NOUVEAU: Style des conteneurs de résultats de recherche bleu */
 .search-result-container {
   background: #1b263b;
@@ -404,16 +341,6 @@ img:hover {
     height: calc(100vh - 70px);
   }
 
-  .login-page [data-testid="stForm"] {
-    width: 95%;
-    margin-top: 4vh;
-    padding: 20px;
-  }
-
-  .login-title {
-    font-size: 24px;
-    margin: 20px 0 16px 0;
-  }
 
   .step-indicator {
     flex-direction: column;
@@ -450,7 +377,4 @@ img:hover {
     padding-top: 75px;
   }
 
-  .login-page [data-testid="stForm"] {
-    padding: 16px;
-  }
 }

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -12,9 +12,8 @@ __all__ = ["load_css", "show_running_ui", "app_header", "login_page", "main_page
 
 
 def login_page() -> None:
-    st.markdown('<div class="app-center login-page"><div class="login-card">', unsafe_allow_html=True)
     st.image("logo.png", width=80)
-    st.markdown('<h2 class="login-title">Connexion</h2>', unsafe_allow_html=True)
+    st.title("Connexion")
     with st.form("login_form", clear_on_submit=False):
         username = st.text_input("Nom d'utilisateur")
         password = st.text_input("Mot de passe", type="password")
@@ -30,7 +29,6 @@ def login_page() -> None:
             st.rerun()
         else:
             st.error("❌ Nom d'utilisateur ou mot de passe incorrect.")
-    st.markdown("</div></div>", unsafe_allow_html=True)
 
 
 def navigate(page_key: str) -> None:

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -37,28 +37,6 @@ html, body, [data-testid="stAppViewContainer"] {
   max-width: 1200px;
 }
 
-.app-center {
-  min-height: calc(100vh - 80px);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.login-card {
-  background: var(--brand-surface);
-  padding: 2.5rem 2rem;
-  border-radius: 16px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.4);
-  width: 100%;
-  max-width: 480px;
-}
-
-.login-title {
-  color: var(--brand-accent);
-  text-align: center;
-  margin-bottom: 1.5rem;
-}
-
 [data-testid="stSidebar"] {
   background: var(--brand-bg);
 }


### PR DESCRIPTION
## Summary
- strip custom CSS and HTML wrappers from Streamlit login pages
- delete login-specific rules from global stylesheet and UI utilities

## Testing
- `python -m py_compile login_app.py ui/utils.py ui/__init__.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5b8d1cebc832b8bc4e81116645af7